### PR TITLE
Fix hardcoded zpool name in scrubbed_at function

### DIFF
--- a/lib/sensu-plugins-zfs/version.rb
+++ b/lib/sensu-plugins-zfs/version.rb
@@ -1,3 +1,3 @@
 module SensuPluginsZFS
-  VERSION = "1.2.3"
+  VERSION = "1.2.4"
 end

--- a/lib/sensu-plugins-zfs/zpool.rb
+++ b/lib/sensu-plugins-zfs/zpool.rb
@@ -29,7 +29,7 @@ module SensuPluginsZFS
       elsif scrub_in_progress?
         return Time.now
       end
-      Time.parse %x[sudo zpool status tank | grep '^  scan: scrub' | awk '{print $11" "$12" "$13" "$14" "$15}'].strip
+      Time.parse %x[sudo zpool status #{@name} | grep '^  scan: scrub' | awk '{print $11" "$12" "$13" "$14" "$15}'].strip
     end
 
     private


### PR DESCRIPTION
I ran into problems using this plugin due to what appears to be a hardcoded zpool name resulting in the error 'cannot open 'tank': no such pool'.

This should fix it up.