### PR TITLE
Fix checking all zpools (#2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,6 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 ### Fixed
 - fix scrub-in-progress command
 - properly parse the list of vdevs
+- fix checking all zpools (#2)
 
 [Unreleased]: https://github.com/sensu-plugins/sensu-plugins-zfs/compare/bf20f6b2538849a9263dbaa8771d649b7173d8b1...HEAD

--- a/bin/check-zpool.rb
+++ b/bin/check-zpool.rb
@@ -34,10 +34,15 @@ class CheckZPool < Sensu::Plugin::Check::CLI
     else
       zpools = SensuPluginsZFS::ZFS.zpools
     end
+    # Looks odd, but we want to check things that can go critical first
     zpools.each do |zp|
       check_state zp
-      check_vdevs zp
+    end
+    zpools.each do |zp|
       check_capacity zp
+    end
+    zpools.each do |zp|
+      check_vdevs zp
       check_recently_scrubbed zp
     end
     if config[:zpool]

--- a/bin/check-zpool.rb
+++ b/bin/check-zpool.rb
@@ -42,8 +42,10 @@ class CheckZPool < Sensu::Plugin::Check::CLI
       check_vdevs zp
       check_recently_scrubbed zp
     end
-    critical @criticals.first unless @criticals.empty?
-    warning @warnings.first unless @warnings.empty?
+    puts @criticals
+    puts @warnings
+    critical @criticals.join(', ') unless @criticals.empty?
+    warning @warnings.join(', ') unless @warnings.empty?
     if config[:zpool]
       ok "zpool #{config[:zpool]} is ok"
     end

--- a/bin/check-zpool.rb
+++ b/bin/check-zpool.rb
@@ -28,23 +28,22 @@ class CheckZPool < Sensu::Plugin::Check::CLI
          default: 7
 
   def run
+    @warnings = []
+    @criticals = []
     zpools = []
     if config[:zpool]
       zpools << SensuPluginsZFS::ZPool.new(config[:zpool])
     else
       zpools = SensuPluginsZFS::ZFS.zpools
     end
-    # Looks odd, but we want to check things that can go critical first
     zpools.each do |zp|
       check_state zp
-    end
-    zpools.each do |zp|
       check_capacity zp
-    end
-    zpools.each do |zp|
       check_vdevs zp
       check_recently_scrubbed zp
     end
+    critical @criticals.first unless @criticals.empty?
+    warning @warnings.first unless @warnings.empty?
     if config[:zpool]
       ok "zpool #{config[:zpool]} is ok"
     end
@@ -54,29 +53,29 @@ class CheckZPool < Sensu::Plugin::Check::CLI
   private
 
   def check_state(zp)
-    critical "zpool #{zp.name} has state #{zp.state}" unless zp.ok?
+    @criticals << "zpool #{zp.name} has state #{zp.state}" unless zp.ok?
   end
 
   def check_vdevs(zp)
     zp.vdevs.each do |vd|
       unless vd.ok?
-        warning "vdev #{vd.name} of zpool #{vd.zpool.name} has errors"
+        @warnings << "vdev #{vd.name} of zpool #{vd.zpool.name} has errors"
       end
     end
   end
 
   def check_capacity(zp)
     if zp.capacity > config[:cap_crit].to_i
-      critical "capacity for zpool #{zp.name} is above #{config[:cap_crit]}% (currently #{zp.capacity}%)"
+      @criticals << "capacity for zpool #{zp.name} is above #{config[:cap_crit]}% (currently #{zp.capacity}%)"
     elsif zp.capacity > config[:cap_warn].to_i
-      warning "capacity for zpool #{zp.name} is above #{config[:cap_warn]}% (currently #{zp.capacity}%)"
+      @warnings << "capacity for zpool #{zp.name} is above #{config[:cap_warn]}% (currently #{zp.capacity}%)"
     end
   end
 
   def check_recently_scrubbed(zp)
     last_scrub = zp.scrubbed_at
     if last_scrub < Time.now - 60 * 60 * 24 * config[:scrubbing_interval].to_i # rubocop:disable Style/GuardClause
-      warning "It is more than #{config[:scrubbing_interval]} days since zpool #{zp.name} was scrubbed. Last scrubbed #{last_scrub}"
+      @warnings << "It is more than #{config[:scrubbing_interval]} days since zpool #{zp.name} was scrubbed. Last scrubbed #{last_scrub}"
     end
   end
 end

--- a/lib/sensu-plugins-zfs/zpool.rb
+++ b/lib/sensu-plugins-zfs/zpool.rb
@@ -3,7 +3,7 @@ require 'time'
 module SensuPluginsZFS
   class ZFS
     def self.zpools
-      `sudo zpool list -H -o name`.lines('').map do |l|
+      `sudo zpool list -H -o name`.lines.map do |l|
         ZPool.new(l.strip)
       end
     end


### PR DESCRIPTION
Also re-order checks so the ones that can go critical are checked first

Before:
```
$ /opt/sensu/embedded/bin/check-zpool.rb
sh: tank: not found
sh: tank2: not found
sh: tank: not found
sh: tank2: not found
sh: tank: not found
sh: tank2: not found
CheckZPool CRITICAL: zpool tank3
tank
tank2 has state pool: tank3
 state: ONLINE
  scan: scrub repaired 0 in XXXXXX with 0 errors on XXXXX config:

	NAME                                            STATE     READ WRITE CKSUM
	tank3                                           ONLINE       0     0     0
	  raidz2-0                                      ONLINE       0     0     0
	    gptid/disk                                  ONLINE       0     0     0
```

After:
```
$ /opt/sensu/embedded/bin/check-zpool.rb
CheckZPool CRITICAL: zpool tank2 has state DEGRADED
```

```
/opt/sensu/embedded/bin/check-zpool.rb -C 1
CheckZPool CRITICAL: capacity for zpool tank1 is above 1% (currently 60%), zpool tank2 has state DEGRADED, capacity for zpool tank2 is above 1% (currently 60%), capacity for zpool tank3 is above 1% (currently 60%)
```

## Pull Request Checklist

**Is this in reference to an existing issue?**

#2 

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [N/A] Update README with any necessary configuration snippets

- [N/A] Binstubs are created if needed

- [x] RuboCop passes

- [N/A] Existing tests pass

#### Purpose

To fix issue #2 

#### Known Compatibility Issues

None