### PR TITLE
[CVE-2017-8418] - updating rubocop dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_install: gem install bundler -v 1.15
 install:
 - bundle install
 rvm:
-- 2.0
 - 2.1
 - 2.2
 - 2.3.0
@@ -28,5 +27,9 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.4.1
+    rvm:
+      - 2.1
+      - 2.2
+      - 2.3.0
+      - 2.4.1
     repo: sensu-plugins/sensu-plugins-zfs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format located [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+
+### Security
+- updated rubocop dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418 (@majormoses)
+
+### Breaking Changes
+- in order to bring in the newer rubocop we had to drop ruby `< 2.1` support (@majormoses)
+
 ### Changed
 - accepted into community, a bunch of initial house keeping (@majormoses)
 

--- a/sensu-plugins-zfs.gemspec
+++ b/sensu-plugins-zfs.gemspec
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
@@ -34,7 +32,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.platform               = Gem::Platform::RUBY
   spec.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   spec.require_paths          = ['lib']
-  spec.required_ruby_version  = '>= 2.0.0'
+  spec.required_ruby_version  = '>= 2.1.0'
   spec.summary                = 'Sensu plugin for zfs'
   spec.test_files             = spec.files.grep(%r{^(test|spec|features)/})
   spec.version                = SensuPluginsZFS::Version::VER_STRING
@@ -46,7 +44,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_development_dependency 'pry',                       '~> 0.10'
   spec.add_development_dependency 'rake',                      '~> 10.0'
   spec.add_development_dependency 'redcarpet',                 '~> 3.2'
-  spec.add_development_dependency 'rubocop',                   '~> 0.49.0'
   spec.add_development_dependency 'rspec',                     '~> 3.1'
+  spec.add_development_dependency 'rubocop',                   '~> 0.51.0'
   spec.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
Breaking Changes:
- removed ruby `< 2.1` support

Misc Changes:
- appeased the cops

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

https://github.com/sensu-plugins/community/issues/77

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose
Resolve CVE (see parent issue for details)

#### Known Compatibility Issues
Removes ruby `< 2.1` support